### PR TITLE
Add unit use-case service implementation

### DIFF
--- a/internal/use-cases/unit/unit.go
+++ b/internal/use-cases/unit/unit.go
@@ -24,7 +24,7 @@ var (
 type Repository interface {
 	GetByID(ctx context.Context, id uuid.UUID) (unitEntity.Unit, error)
 	GetByIDs(ctx context.Context, ids []uuid.UUID) ([]unitEntity.Unit, error)
-	GetAll(ctx context.Context, substring mo.Option[string]) ([]unitEntity.Unit, error)
+	GetAll(ctx context.Context, userID uuid.UUID, substring mo.Option[string]) ([]unitEntity.Unit, error)
 	Create(ctx context.Context, unit unitEntity.Unit) error
 	Update(ctx context.Context, unit unitEntity.Unit) error
 }
@@ -54,12 +54,12 @@ func (u *UseCase) GetByIDs(ctx context.Context, ids []uuid.UUID) ([]unitEntity.U
 }
 
 // GetAll returns all units, optionally filtered by name substring.
-func (u *UseCase) GetAll(ctx context.Context, substring mo.Option[string]) ([]unitEntity.Unit, error) {
+func (u *UseCase) GetAll(ctx context.Context, userID uuid.UUID, substring mo.Option[string]) ([]unitEntity.Unit, error) {
 	if substring.IsPresent() && substring.MustGet() == "" {
 		return nil, errors.Join(ErrBadParams, fmt.Errorf("substring must not be empty when set"))
 	}
 
-	units, err := u.repo.GetAll(ctx, substring)
+	units, err := u.repo.GetAll(ctx, userID, substring)
 	if err != nil {
 		return nil, fmt.Errorf("get all units: %w", err)
 	}
@@ -68,8 +68,8 @@ func (u *UseCase) GetAll(ctx context.Context, substring mo.Option[string]) ([]un
 }
 
 // Create creates a new unit.
-func (u *UseCase) Create(ctx context.Context, userID mo.Option[uuid.UUID], name string) (unitEntity.Unit, error) {
-	unit := unitEntity.New(userID, name)
+func (u *UseCase) Create(ctx context.Context, userID uuid.UUID, name string) (unitEntity.Unit, error) {
+	unit := unitEntity.New(mo.Some(userID), name)
 	if err := unit.Validate(); err != nil {
 		return unitEntity.Unit{}, errors.Join(ErrBadParams, fmt.Errorf("validate unit create: %w", err))
 	}

--- a/internal/use-cases/unit/unit.go
+++ b/internal/use-cases/unit/unit.go
@@ -1,0 +1,127 @@
+package unit
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	unitEntity "go-unit-service/internal/entities/unit"
+
+	"github.com/google/uuid"
+	"github.com/samber/mo"
+)
+
+// Repository defines persistence operations for units.
+type Repository interface {
+	GetByID(ctx context.Context, id uuid.UUID) (unitEntity.Unit, error)
+	GetAll(ctx context.Context) ([]unitEntity.Unit, error)
+	Create(ctx context.Context, unit unitEntity.Unit) error
+	Update(ctx context.Context, unit unitEntity.Unit) error
+}
+
+// Service provides business logic for units.
+type Service struct {
+	repo Repository
+}
+
+// NewService builds a Service.
+func NewService(repo Repository) *Service {
+	return &Service{repo: repo}
+}
+
+// ErrUserIDMismatch indicates the update user does not match the unit owner.
+var ErrUserIDMismatch = errors.New("unit user id does not match")
+
+// ErrUserIDMissing indicates the unit has no user id set.
+var ErrUserIDMissing = errors.New("unit user id is missing")
+
+// GetByID returns a unit by id.
+func (s *Service) GetByID(ctx context.Context, id uuid.UUID) (unitEntity.Unit, error) {
+	return s.repo.GetByID(ctx, id)
+}
+
+// GetAll returns all units without pagination.
+func (s *Service) GetAll(ctx context.Context) ([]unitEntity.Unit, error) {
+	return s.repo.GetAll(ctx)
+}
+
+// GetAllFiltered returns all units filtered by name substring.
+func (s *Service) GetAllFiltered(ctx context.Context, substring string) ([]unitEntity.Unit, error) {
+	units, err := s.repo.GetAll(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if substring == "" {
+		return units, nil
+	}
+
+	filtered := make([]unitEntity.Unit, 0, len(units))
+	for _, unit := range units {
+		if strings.Contains(unit.Name, substring) {
+			filtered = append(filtered, unit)
+		}
+	}
+
+	return filtered, nil
+}
+
+// Create creates a new unit.
+func (s *Service) Create(ctx context.Context, userID mo.Option[uuid.UUID], name string) (unitEntity.Unit, error) {
+	unit := unitEntity.New(userID, name)
+	if err := unit.Validate(); err != nil {
+		return unitEntity.Unit{}, err
+	}
+
+	if err := s.repo.Create(ctx, unit); err != nil {
+		return unitEntity.Unit{}, err
+	}
+
+	return unit, nil
+}
+
+// Update updates a unit by id and user id.
+func (s *Service) Update(ctx context.Context, id uuid.UUID, userID uuid.UUID, name string) (unitEntity.Unit, error) {
+	unit, err := s.repo.GetByID(ctx, id)
+	if err != nil {
+		return unitEntity.Unit{}, err
+	}
+
+	if !unit.UserID.IsPresent() {
+		return unitEntity.Unit{}, ErrUserIDMissing
+	}
+
+	if unit.UserID.MustGet() != userID {
+		return unitEntity.Unit{}, ErrUserIDMismatch
+	}
+
+	unit.Touch()
+	unit.Name = name
+
+	if err := unit.Validate(); err != nil {
+		return unitEntity.Unit{}, fmt.Errorf("validate unit update: %w", err)
+	}
+
+	if err := s.repo.Update(ctx, unit); err != nil {
+		return unitEntity.Unit{}, err
+	}
+
+	return unit, nil
+}
+
+// Delete marks the unit as deleted and saves it.
+func (s *Service) Delete(ctx context.Context, id uuid.UUID) (unitEntity.Unit, error) {
+	unit, err := s.repo.GetByID(ctx, id)
+	if err != nil {
+		return unitEntity.Unit{}, err
+	}
+
+	unit.MarkDeleted()
+
+	if err := s.repo.Update(ctx, unit); err != nil {
+		return unitEntity.Unit{}, err
+	}
+
+	return unit, nil
+}


### PR DESCRIPTION
### Motivation
- Implement business logic for the `Unit` entity according to the issue: provide a use-case/service layer that exposes CRUD operations and enforces business rules. 
- Support listing all units, filtering by substring, creating, updating with ownership checks and `Touch()`, and soft-deleting with `MarkDeleted()`.
- Represent persistence as an interface so the service can be wired to different repositories.

### Description
- Added new package `internal/use-cases/unit` with the repository interface (`GetByID`, `GetAll`, `Create`, `Update`) and `Service` type with `NewService` constructor.
- Implemented `GetByID`, `GetAll`, and `GetAllFiltered` which returns units filtered by name substring. 
- Implemented `Create` which builds a `Unit` via `unitEntity.New`, validates it with `Validate()`, and persists it via the repository. 
- Implemented `Update` which loads the entity, ensures `UserID` is present and equals the caller `userID`, calls `Touch()`, updates fields, validates, and persists; defined `ErrUserIDMissing` and `ErrUserIDMismatch` for validation failures.
- Implemented `Delete` which loads the entity, calls `MarkDeleted()`, and saves it back via the repository.

### Testing
- No automated tests were added or run for this change. 
- Code was formatted with `gofmt -w internal/use-cases/unit/unit.go` before committing. 
- The change is a self-contained implementation ready to be wired to a repository and covered by unit tests in follow-ups.

------

Issue: #2

[Codex Task](https://chatgpt.com/codex/tasks/task_e_697dfecf7d30832bbbb19228d200f2c7)